### PR TITLE
Add Enable Anti-Cheat game option shown in game filters

### DIFF
--- a/package/Resources/GameLobbyBase.ini
+++ b/package/Resources/GameLobbyBase.ini
@@ -173,6 +173,7 @@ $CC_22=chkBuildOffAlly:GameLobbyCheckBox
 $CC_23=chkParabombsInMultiplayer:GameLobbyCheckBox
 $CC_24=chkShortGame:GameLobbyCheckBox
 $CC_25=chkForcedAlliances:GameLobbyCheckBox
+$CC_26=chkAC:GameLobbyCheckBox
 
 [cmbGameType]
 $Width=97
@@ -498,3 +499,15 @@ $BaseSection=ddPlayerStartBase
 
 [ddPlayerStart7]
 $BaseSection=ddPlayerStartBase
+
+[chkAC]
+Text=Enable Anti-Cheat
+SpawnIniOption=AC
+Checked=False
+EnabledSpawnIniValue=Yes
+DisabledSpawnIniValue=No
+BroadcastToLobby=true
+ShowInFilters=true
+ToolTip=When enabled, all players must run the anti-cheat software for the match to start.
+$X=getX(chkAftermathFastBuildSpeed)
+$Y=getY(chkAftermathFastBuildSpeed) + CHECKBOX_SPACING

--- a/package/Resources/GameLobbyBase.ini
+++ b/package/Resources/GameLobbyBase.ini
@@ -503,7 +503,7 @@ $BaseSection=ddPlayerStartBase
 [chkAC]
 Text=Enable Anti-Cheat
 SpawnIniOption=AC
-Checked=False
+Checked=True
 EnabledSpawnIniValue=Yes
 DisabledSpawnIniValue=No
 BroadcastToLobby=true


### PR DESCRIPTION
Adds a generic `chkAC` game option to the Red Alert lobby (`GameOptionsPanel`), configured to appear in the game filters via `BroadcastToLobby=true` and `ShowInFilters=true`. No client/engine code changes — a purely generic game option, per client design guidance.

- Shows in both skirmish and online lobbies (the online lobby inherits `GameOptionsPanel`).
- Filterable in the game list as All / On / Off.
- Writes the `AC` spawn.ini option (Yes/No).
- Defaults to unchecked; hosts opt in.